### PR TITLE
hotfix - server returning report object with only ID

### DIFF
--- a/src/Components/SearchBar/SearchBar.service.js
+++ b/src/Components/SearchBar/SearchBar.service.js
@@ -12,13 +12,20 @@ export class SearchBarService {
   /*
 filterReports(arr, input)
 takes array and input value, and searches array by company name, or candidate name
+- for created new report object, we need to bypass them, because those objects have only ID property.
+- so we give condition, to filter by candidate name or company name, only for those object that have candidateName property,
+  and for those "empty" report objects, we just return them
 */
   filterReports(arr, input) {
     const filtered = arr.filter((item) => {
-      return (
-        item.candidateName.toUpperCase().includes(input.toUpperCase()) ||
-        item.companyName.toUpperCase().includes(input.toUpperCase())
-      );
+      if (item.candidateName) {
+        return (
+          item.candidateName.toUpperCase().includes(input.toUpperCase()) ||
+          item.companyName.toUpperCase().includes(input.toUpperCase())
+        );
+      } else {
+        return item;
+      }
     });
 
     return filtered;


### PR DESCRIPTION
Now we can filter all reports objects, and the filter method inside "searchBar service" returns filtered objects and returns "empty" server objects also.